### PR TITLE
Fix bug for counting bloom filter

### DIFF
--- a/bloompy/__init__.py
+++ b/bloompy/__init__.py
@@ -213,8 +213,6 @@ class CountingBloomFilter(BloomFilter):
 		'''
 		if self.count >= self.capacity:
 			raise IndexError('BloomFilter is at capacity.')
-		if element in self:
-			return True
 		_element = self._to_str(element)
 		i = 0
 		for _ in range(self.hash_num):


### PR DESCRIPTION
Hi, I tested your script and found a bug.

Updating Counting Bloom Filter's is necessary when an element is added to CBF, while simply `return True`  will ignore the counters' updating steps.